### PR TITLE
fix: キャッシュミスとPR無しの状態を明確に区別する

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -14,6 +14,9 @@ import type { PRInfo } from "./pr";
 import { debug } from "./utils/debug";
 import { tryCatch } from "./utils/result";
 
+// キャッシュ結果の型
+export type CacheResult = { data: PRInfo | null } | null;
+
 // キャッシュの有効期限（24時間）
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -62,8 +65,9 @@ function hasValidCache(cacheFile: string): boolean {
 
 /**
  * キャッシュ取得
+ * @returns キャッシュ結果（ヒット時は{data: PRInfo|null}、ミス時はnull）
  */
-export function getCache(gitInfo: GitInfo): PRInfo | null {
+export function getCache(gitInfo: GitInfo): CacheResult {
   const { cacheDir, headFile, cacheFile } = getCachePaths(gitInfo);
 
   // ディレクトリ作成
@@ -99,7 +103,7 @@ export function getCache(gitInfo: GitInfo): PRInfo | null {
     return null;
   }
 
-  return parsed.value;
+  return { data: parsed.value };
 }
 
 /**

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -74,7 +74,7 @@ export async function getPRInfo(gitInfo: GitInfo): Promise<PRInfo | null> {
   const cached = getCache(gitInfo);
   if (cached) {
     debug(`Using cache for ${gitInfo.currentBranch}`);
-    return cached;
+    return cached.data;
   }
 
   // キャッシュがない場合は新規取得


### PR DESCRIPTION
## 概要

- キャッシュファイルをfalsyで判定していたため、PRが存在しない場合（data: null）もキャッシュミスと誤判定されていたのを修正する

## 変更内容

- getCache() の戻り値を CacheResult 型 ({ data: PRInfo | null } | null) に変更
- キャッシュヒット時は { data: PRInfo | null } を返す
- キャッシュミス時は null を返す

## 影響

- 影響範囲：getCache関数の戻り値の型が変更
- 破壊的変更：なし（既存の動作は維持）