### PR TITLE
feat: Bunパッケージキャッシュをクリアするupdateサブコマンドを追加

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,10 @@
-import { cli, define } from "gunshi";
+import { type Args, type Command, cli, define } from "gunshi";
 import packageJson from "../package.json";
-import { execute } from "./core";
+import { main } from "./commands/main";
+import { update } from "./commands/update";
 
-// CLIコマンド定義
-const command = define({
+// メインコマンド定義
+const mainCommand = define({
   name: "github-pr-info",
   description: "Get GitHub PR information for current git branch",
   args: {
@@ -16,16 +17,27 @@ const command = define({
   },
   run: async (ctx) => {
     const { debug: debugMode } = ctx.values;
-
-    await execute({
-      debugMode,
-    });
+    await main(debugMode);
   },
 });
 
+// updateサブコマンド定義
+const updateCommand = define({
+  name: "update",
+  description: "Clear cache to get latest version",
+  run: async () => {
+    await update();
+  },
+});
+
+// サブコマンドマップ
+const subCommands = new Map<string, Command<Args>>();
+subCommands.set("update", updateCommand);
+
 // CLI実行
 export function runCLI(argv: string[]) {
-  cli(argv, command, {
+  cli(argv, mainCommand, {
     version: packageJson.version,
+    subCommands,
   });
 }

--- a/src/commands/main.ts
+++ b/src/commands/main.ts
@@ -1,13 +1,8 @@
-import { getGitInfo } from "./git";
-import { getPRInfo, type PRInfo } from "./pr";
-import { debug, setDebugMode } from "./utils/debug";
+import { getGitInfo } from "../git";
+import { getPRInfo, type PRInfo } from "../pr";
+import { debug, setDebugMode } from "../utils/debug";
 
-// CLIオプションの型定義
-export interface Options {
-  debugMode: boolean;
-}
-
-// PR情報を表示（フォーマット対応）
+// PR情報を表示
 function displayPRInfo(prInfo: PRInfo | null): void {
   if (prInfo === null) {
     console.log("[no PR]");
@@ -23,10 +18,10 @@ function displayPRInfo(prInfo: PRInfo | null): void {
   console.log(formatted);
 }
 
-// PR情報取得と表示のメインロジック
-export async function execute(options: Options): Promise<void> {
+// メインコマンドの実行処理
+export async function main(debugMode: boolean): Promise<void> {
   // デバッグモード設定
-  if (options.debugMode) {
+  if (debugMode) {
     setDebugMode(true);
   }
 
@@ -41,7 +36,7 @@ export async function execute(options: Options): Promise<void> {
     return;
   }
 
-  // PR情報を取得（no-cacheオプション対応は後で実装）
+  // PR情報を取得
   const prInfo = await getPRInfo(result.value);
 
   // 表示

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,21 @@
+import { $ } from "bun";
+
+// updateコマンドの実行処理
+export async function update(): Promise<void> {
+  console.log("Clearing cache for github-pr-info...");
+
+  // bunxで使用されるパッケージキャッシュを削除
+  // 次回bunx実行時に最新版がダウンロードされる
+  const { exitCode } =
+    await $`bun pm cache rm github.com/miyaoka/github-pr-info`
+      .quiet()
+      .nothrow();
+
+  if (exitCode !== 0) {
+    console.log("⚠ Failed to clear cache");
+    return;
+  }
+
+  console.log("✓ Cache cleared");
+  console.log("Next run will fetch the latest version");
+}


### PR DESCRIPTION
## 概要
bunxのキャッシュをクリアして最新版を取得するための `update` サブコマンドを実装しました。

## 変更内容
- core.tsを削除し、ロジックをcommands/に分離
- commands/main.ts: メインコマンドの処理
- commands/update.ts: キャッシュクリア処理
- cli.ts: gunshiのサブコマンド機能を使用して実装

## 使い方
```bash
# キャッシュをクリア
bunx github:miyaoka/github-pr-info update

# 通常実行
bunx github:miyaoka/github-pr-info
```

## テスト
- [x] updateコマンドでキャッシュがクリアされることを確認
- [x] 通常実行が正常に動作することを確認