### PR TITLE
キャッシュ有効期限を1分に短縮して情報の鮮度を向上

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -17,8 +17,8 @@ import { tryCatch } from "./utils/result";
 // キャッシュ結果の型
 export type CacheResult = { data: PRInfo | null } | null;
 
-// キャッシュの有効期限（24時間）
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+// キャッシュの有効期限（1分）
+const CACHE_TTL_MS = 60 * 1000;
 
 // パス生成
 function getCachePaths(gitInfo: GitInfo) {


### PR DESCRIPTION
## 概要
PR情報のキャッシュ有効期限を24時間から1分に変更

## 背景
- GitHub APIへのPR情報取得には約0.5秒かかる
- ターミナル操作（プロンプト表示など）のたびにこの待ち時間が発生するのを防ぐためキャッシュを実装
- 現状24時間のキャッシュでは情報が古くなりがち

## 変更内容
- `CACHE_TTL_MS` を `24 * 60 * 60 * 1000` から `60 * 1000` に変更

## メリット
- 1分に1回程度の更新頻度なら体感的な遅延は問題ない
- PR情報がより最新の状態で表示される
- レビューコメントやステータス変更などがタイムリーに反映される